### PR TITLE
Add JUnit test for login greeting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,10 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok:1.18.30'
 	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
-	testImplementation 'junit:junit:4.12'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
-	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+        testImplementation 'junit:junit:4.12'
+        testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+        testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+        testImplementation 'org.mockito:mockito-core:3.12.4'
 }
 
 group = 'com.bankstandscape'

--- a/src/main/java/com/bankstandscape/BankStandscapePlugin.java
+++ b/src/main/java/com/bankstandscape/BankStandscapePlugin.java
@@ -39,11 +39,11 @@ public class BankStandscapePlugin extends Plugin
 	@Subscribe
 	public void onGameStateChanged(GameStateChanged gameStateChanged)
 	{
-		if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
-		{
-			client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Bank Standscape Plugin enabled!", null);
-		}
-	}
+                if (gameStateChanged.getGameState() == GameState.LOGGED_IN)
+                {
+                        client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", config.greeting(), null);
+                }
+        }
 
 	@Provides
 	BankStandscapeConfig provideConfig(ConfigManager configManager)

--- a/src/test/java/com/bankstandscape/BankStandscapePluginTest.java
+++ b/src/test/java/com/bankstandscape/BankStandscapePluginTest.java
@@ -1,13 +1,42 @@
 package com.bankstandscape;
 
-import net.runelite.client.RuneLite;
-import net.runelite.client.externalplugins.ExternalPluginManager;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.GameState;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.Client;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
 public class BankStandscapePluginTest
 {
-	public static void main(String[] args) throws Exception
-	{
-		ExternalPluginManager.loadBuiltin(BankStandscapePlugin.class);
-		RuneLite.main(args);
-	}
+    @Mock
+    private Client client;
+
+    @Mock
+    private BankStandscapeConfig config;
+
+    @InjectMocks
+    private BankStandscapePlugin plugin;
+
+    @Test
+    public void testChatMessageOnLogin()
+    {
+        String greeting = "Hello";
+        when(config.greeting()).thenReturn(greeting);
+
+        GameStateChanged event = new GameStateChanged();
+        event.setGameState(GameState.LOGGED_IN);
+
+        plugin.onGameStateChanged(event);
+
+        verify(client).addChatMessage(ChatMessageType.GAMEMESSAGE, "", greeting, null);
+    }
 }
+


### PR DESCRIPTION
## Summary
- Replace manual test harness with JUnit test using Mockito
- Use configuration greeting for login chat message
- Add Mockito to test dependencies

## Testing
- `./gradlew test` *(fails: Could not resolve net.runelite:client due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68aec0821b2483209b0756a9fad7ed15